### PR TITLE
npm run build .

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ COPY .npmrc .
 COPY package.json .
 COPY package-lock.json .
 RUN npm ci
-RUN npm run build
 
 COPY . .
+
+RUN npm run build
 RUN npm pack

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carbon-ts-protoc-gen",
-  "version": "0.9.2-pre",
+  "version": "0.9.3-pre",
   "description": "Protoc Plugin for TypeScript Declarations and Service Definitions",
   "scripts": {
     "lint": "tslint -c tslint.json 'test/**/*.ts' 'src/**/*.ts'",


### PR DESCRIPTION
The `lib` folder is missing in the package. I think it is because of the order in Dockerfile. I moved the build command after copying all the files.